### PR TITLE
added the temporary path option for windows

### DIFF
--- a/jpegexport.inx
+++ b/jpegexport.inx
@@ -4,6 +4,7 @@
         <dependency type="executable" location="extensions">jpegexport.py</dependency>
 		<param name="help" type="description">Please select the area of the drawing that you wish to export and then provide the exported file name (with full path) and the background color of the exported jpeg.</param>
         <param name="path" type="string"  _gui-text="Export path">~</param>
+		<param name="tmppath" type="string"  _gui-text="Temporary path">/tmp/</param>
 		<param name="bgcol" type="string" _gui-text="Background color">#ffffff</param>
 		<param name="page" type="boolean" _gui-text="Export whole page">false</param>
 		<param name="fast" type="boolean" _gui-text="Fast export (suggested)">true</param>

--- a/languages/ja/jpegexport.inx
+++ b/languages/ja/jpegexport.inx
@@ -4,6 +4,7 @@
         <dependency type="executable" location="extensions">jpegexport.py</dependency>
 		<param name="help" type="description">エクスポートしたい描画領域を選択し、エクスポートされるファイル名（フルパス）とJPEGの背景色を入力してください。 </param>
         <param name="path" type="string"  _gui-text="エクスポートパス">~</param>
+		<param name="tmppath" type="string" _gui-text="テンポラリパス">/tmp/</param>
 		<param name="bgcol" type="string" _gui-text="背景色">#ffffff</param>
 		<param name="page" type="boolean" _gui-text="ページ全体をエクスポート">false</param>
 		<param name="fast" type="boolean" _gui-text="高速エクスポート (推奨)">true</param>


### PR DESCRIPTION
This extension doesn't work in Windows. Because the temporary path (/tmp/)  does not exist in Windows. I've added a temporary path to the option.
If you think not good, please refuse.
Thanks.
